### PR TITLE
Improve TFT_eSPI configuration and add debug output

### DIFF
--- a/include/User_Setup.h
+++ b/include/User_Setup.h
@@ -55,5 +55,17 @@
 #define SPI_READ_FREQUENCY  16000000  // 16 MHz for reading
 #define SPI_TOUCH_FREQUENCY  2500000  // 2.5 MHz for touch
 
-// Use hardware SPI
+// Use HSPI port for ESP32 (the CYD uses HSPI for display)
 #define USE_HSPI_PORT
+
+// ##################################################################################
+// Optional: Color inversion (uncomment if colors look wrong)
+// ##################################################################################
+// #define TFT_INVERSION_ON
+// #define TFT_INVERSION_OFF
+
+// ##################################################################################
+// Optional: Color order (uncomment if red/blue swapped)
+// ##################################################################################
+// #define TFT_RGB_ORDER TFT_RGB  // Colour order Red-Green-Blue
+// #define TFT_RGB_ORDER TFT_BGR  // Colour order Blue-Green-Red

--- a/platformio.ini
+++ b/platformio.ini
@@ -19,7 +19,7 @@ lib_deps =
     bodmer/TFT_eSPI@^2.5.43
     https://github.com/PaulStoffregen/XPT2046_Touchscreen.git
 
-; Point TFT_eSPI to our User_Setup.h in the include folder
+; TFT_eSPI configuration - force include our User_Setup.h
 build_flags =
-    -Iinclude
     -DUSER_SETUP_LOADED=1
+    -include include/User_Setup.h

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -244,7 +244,7 @@ void setup() {
     delay(100);
     Serial.println("\n=== Times Table Quiz ===");
 
-    // Initialize backlight
+    // Initialize backlight FIRST
     pinMode(TFT_BACKLIGHT, OUTPUT);
     digitalWrite(TFT_BACKLIGHT, HIGH);
     Serial.println("Backlight ON");
@@ -252,6 +252,20 @@ void setup() {
     // Initialize display
     tft.init();
     tft.setRotation(1);  // Landscape mode
+
+    // Print TFT_eSPI driver info for debugging
+    Serial.print("TFT_eSPI ver: ");
+    Serial.println(TFT_ESPI_VERSION);
+    Serial.print("Display driver: ");
+    #if defined(ILI9341_DRIVER) || defined(ILI9341_2_DRIVER)
+    Serial.println("ILI9341");
+    #elif defined(ST7789_DRIVER)
+    Serial.println("ST7789");
+    #else
+    Serial.println("Unknown");
+    #endif
+    Serial.printf("Display size: %d x %d\n", tft.width(), tft.height());
+
     tft.fillScreen(COLOR_BG);
     Serial.println("Display initialized");
 


### PR DESCRIPTION
- Use -include flag to force User_Setup.h loading
- Add driver detection debug output to serial
- Add optional color inversion/order settings (commented)
- Print TFT_eSPI version and driver info at startup