### PR TITLE
Fix SPI bus conflict - use HSPI for display, VSPI for touch

### DIFF
--- a/include/User_Setup.h
+++ b/include/User_Setup.h
@@ -53,10 +53,12 @@
 #define SMOOTH_FONT
 
 // ##################################################################################
-// SPI configuration - use VSPI (default), NOT HSPI
+// SPI configuration
 // ##################################################################################
 #define SPI_FREQUENCY       65000000
 #define SPI_READ_FREQUENCY  80000000
 #define SPI_TOUCH_FREQUENCY  2500000
 
-// NOTE: Do NOT define USE_HSPI_PORT - CYD works with default VSPI
+// IMPORTANT: Use HSPI for display (pins 12,13,14 are HSPI)
+// This frees up VSPI for the touch controller
+#define USE_HSPI_PORT


### PR DESCRIPTION
Display pins (12,13,14) are HSPI pins, so TFT_eSPI should use HSPI. This frees up VSPI for the XPT2046 touch controller.

The touch was returning x=0 y=0 z=4095 because of bus conflict.