### PR TITLE
Switch to TFT_eSPI built-in touch support

### DIFF
--- a/include/User_Setup.h
+++ b/include/User_Setup.h
@@ -32,7 +32,13 @@
 #define TFT_RST  -1
 #define TFT_BL   27  // IMPORTANT: Backlight is GPIO 27, NOT 21!
 
-#define TOUCH_CS 33
+// ##################################################################################
+// Touch pins - XPT2046 on separate SPI bus
+// ##################################################################################
+#define TOUCH_CS   33
+#define TOUCH_MISO 39
+#define TOUCH_MOSI 32
+#define TOUCH_CLK  25
 
 // ##################################################################################
 // Backlight control

--- a/platformio.ini
+++ b/platformio.ini
@@ -17,7 +17,6 @@ board_build.partitions = huge_app.csv
 
 lib_deps =
     bodmer/TFT_eSPI@^2.5.43
-    https://github.com/PaulStoffregen/XPT2046_Touchscreen.git
 
 ; TFT_eSPI configuration - force include our User_Setup.h
 build_flags =


### PR DESCRIPTION
- Remove XPT2046_Touchscreen library (was conflicting)
- Add TOUCH_MISO, TOUCH_MOSI, TOUCH_CLK pins to User_Setup.h
- Use tft.getTouch() instead of separate touch library
- Add touch calibration data for landscape mode

TFT_eSPI can handle touch on separate SPI pins natively.