### PR TITLE
Try different touch calibration rotation value

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,7 +24,9 @@
 
 // Touch calibration values for TFT_eSPI (landscape mode)
 // Known-good values for CYD ESP32-2432S028
-uint16_t touchCalData[5] = {391, 3491, 266, 3610, 7};
+// Format: {minX, maxX, minY, maxY, rotation}
+// Trying rotation 1 (invert Y only)
+uint16_t touchCalData[5] = {300, 3600, 300, 3600, 1};
 bool touchCalibrated = false;
 
 // Display dimensions


### PR DESCRIPTION
Previous calibration (rotation 7) had wrong axis mapping. Trying rotation 1 (invert Y only) with standard min/max values.

Touch was reading x=34-124, y=70-82 when buttons are at y=130+ This suggests Y axis needs different handling.