### PR TITLE
Try rotation 6 for touch calibration (swap X/Y + invert X)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,8 +25,8 @@
 // Touch calibration values for TFT_eSPI (landscape mode)
 // Known-good values for CYD ESP32-2432S028
 // Format: {minX, maxX, minY, maxY, rotation}
-// Trying rotation 5 (swap X/Y + invert Y)
-uint16_t touchCalData[5] = {300, 3600, 300, 3600, 5};
+// Trying rotation 6 (swap X/Y + invert X)
+uint16_t touchCalData[5] = {300, 3600, 300, 3600, 6};
 bool touchCalibrated = false;
 
 // Display dimensions


### PR DESCRIPTION
Debug showed touch Y maps to horizontal position but inverted. Rotation 6 should fix: swap axes then invert X to correct horizontal mapping.