### PR TITLE
Try rotation 7 for touch calibration (swap X/Y + invert both)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,8 +25,8 @@
 // Touch calibration values for TFT_eSPI (landscape mode)
 // Known-good values for CYD ESP32-2432S028
 // Format: {minX, maxX, minY, maxY, rotation}
-// Trying rotation 6 (swap X/Y + invert X)
-uint16_t touchCalData[5] = {300, 3600, 300, 3600, 6};
+// Trying rotation 7 (swap X/Y + invert both X and Y)
+uint16_t touchCalData[5] = {300, 3600, 300, 3600, 7};
 bool touchCalibrated = false;
 
 // Display dimensions


### PR DESCRIPTION
Rotation 6 showed both axes inverted from expected:
- Visual left gave high X, need low X
- Visual top gave high Y, need low Y Rotation 7 adds Y inversion to fix both axes.